### PR TITLE
Add ability to get metadata about cached data

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ var handler = mightyCache.handler(cacheImpl, {
 });
 
 app.route('/cache/:username')
+   .head(handler.head)
    .get(handler.restore)
    .post(handler.save)
    .delete(handler.remove);
@@ -157,7 +158,21 @@ As this is meant solely for testing purposes it currently has no required parame
 ## Cache Implementation
 Every implementation **must** implement the following methods:
 
-### restore(key, [ifNewerHash])
+### head(key[, ifNewerHash])
+Retrieves the cached metadata for the provided key.
+
+* key `String`. **Required**. Identifies the item to retrieve the metadata for
+
+```js
+var cache = mightyCache.cache(cacheImplName, options);
+cache.restore('test-key').then(function(data) {
+  // Metadata successfully retrieved, `data.etag` has the hash of the currently cached value
+}, function(reason) {
+  // Something went wrong
+});
+```
+
+### restore(key[, ifNewerHash])
 Restores the cached data for the provided key.
 
 * key `String`. **Required**. Identifies the data being retrieved
@@ -172,7 +187,7 @@ cache.restore('test-key').then(function(data) {
 });
 ```
 
-### save(dataToBeCached, key, [hashToReplace])
+### save(dataToBeCached, key[, hashToReplace])
 Stores the data for the provided key.
 
 * dataToBeCached `String`. **Required**. The data to be stored
@@ -188,7 +203,7 @@ cache.save('Test Data', 'test-key').then(function(data) {
 });
 ```
 
-### remove(key, [hashToDelete])
+### remove(key[, hashToDelete])
 Deletes the cached data for the provided key.
 
 * key `String`. **Required**. Identifies the data being deleted
@@ -215,13 +230,13 @@ cache.keys().then(function(keys) {
 });
 ```
 
-### set(key)
+### set(name)
 Creates an instance of a Set. This allows grouping many items under any given key. The Set instance supports all
 the methods of a Cache instance with the exception of set. You are not allowed to create a set form a set instance. Multiple
 sets can be created for each cache, if the same set key is requested a new one will not be create but it will be retrieve
 a cached set.
 
-* key `String`. **Required**. Key of the hash set
+* name `String`. **Required**. Name of the hash set
 
 ```js
 var cache = mightyCache.cache(cacheImplName, options);

--- a/lib/cacheImpl/fs.js
+++ b/lib/cacheImpl/fs.js
@@ -172,6 +172,40 @@
     };
 
     /**
+     * Retrieves the metadata for the provided key.
+     *
+     * @example
+     * ```js
+     * var cache = cacheModule.cache(cacheImplName, options);
+     * cache.head('test-key').then(function(data) {
+     *   // Metadata successfully retrieved, `data.etag` has the hash of the currently cached value
+     * }, function(reason) {
+     *   // Something went wrong
+     * });
+     * ```
+     *
+     * @param key `String`. **Required**. Identifies the data being retrieved
+     * @returns {Q.promise}
+     */
+    FSCache.prototype.head = function (key) {
+        var self = this,
+            urlEncodedKey = encodeURIComponent(key),
+            deferred = Q.defer(),
+            readFile = cbQ.cb();
+
+        self.xfs.readFile(path.join(self.path, urlEncodedKey), readFile);
+        readFile.promise.then(function (data) {
+            deferred.resolve({
+                etag: getSHA1(data.toString())
+            });
+        }, function () {
+            var err = errors.errorCodes.CACHE_NOT_FOUND;
+            deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+        });
+        return deferred.promise;
+    };
+
+    /**
      * Restores the cached data for the provided key.
      *
      * @example

--- a/lib/cacheImpl/mem.js
+++ b/lib/cacheImpl/mem.js
@@ -129,6 +129,40 @@
     };
 
     /**
+     * Retrieves the metadata for the provided key.
+     *
+     * @example
+     * ```js
+     * var cache = cacheModule.cache(cacheImplName, options);
+     * cache.head('test-key').then(function(data) {
+     *   // Metadata successfully retrieved, `data.etag` has the hash of the currently cached value
+     * }, function(reason) {
+     *   // Something went wrong
+     * });
+     * ```
+     *
+     * @param key `String`. **Required**. Identifies the data being retrieved
+     * @returns {Q.promise}
+     */
+    TestCache.prototype.head = function (key) {
+        var deferred = Q.defer(),
+            self = this;
+
+        process.nextTick(function () {
+            var data = self.cache.get(key);
+            if (data) {
+                deferred.resolve({
+                    etag: data.hash
+                });
+            } else {
+                var err = errors.errorCodes.CACHE_NOT_FOUND;
+                deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+            }
+        });
+        return deferred.promise;
+    };
+
+    /**
      * Restores the cached data for the provided key.
      *
      * @example

--- a/lib/cacheImpl/redis.js
+++ b/lib/cacheImpl/redis.js
@@ -183,6 +183,39 @@
     };
 
     /**
+     * Retrieves the metadata for the provided key.
+     *
+     * @example
+     * ```js
+     * var cache = cacheModule.cache(cacheImplName, options);
+     * cache.head('test-key').then(function(data) {
+     *   // Metadata successfully retrieved, `data.etag` has the hash of the currently cached value
+     * }, function(reason) {
+     *   // Something went wrong
+     * });
+     * ```
+     *
+     * @param key `String`. **Required**. Identifies the data being retrieved
+     * @returns {Q.promise}
+     */
+    RedisCache.prototype.head = function (key) {
+        var self = this,
+            deferred = Q.defer();
+
+        self.redisClient.get(key, function (redisErr, data) {
+            if (redisErr || !data) {
+                var err = errors.errorCodes.CACHE_NOT_FOUND;
+                return deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+            }
+
+            deferred.resolve({
+                etag: getSHA1(data)
+            });
+        });
+        return deferred.promise;
+    };
+
+    /**
      * Restores the cached data for the provided key.
      *
      * @example

--- a/lib/cacheImpl/s3.js
+++ b/lib/cacheImpl/s3.js
@@ -172,6 +172,38 @@
     };
 
     /**
+     * Retrieves the metadata for the provided key.
+     *
+     * @example
+     * ```js
+     * var cache = cacheModule.cache(cacheImplName, options);
+     * cache.head('test-key').then(function(data) {
+     *   // Metadata successfully retrieved, `data.etag` has the hash of the currently cached value
+     * }, function(reason) {
+     *   // Something went wrong
+     * });
+     * ```
+     *
+     * @param key `String`. **Required**. Identifies the data being retrieved
+     * @returns {Q.promise}
+     */
+    S3Cache.prototype.head = function (key) {
+        var self = this,
+            urlEncodedKey = encodeURIComponent(key),
+            deferred = Q.defer();
+
+        self.s3fs.headObject(urlEncodedKey).then(function (data) {
+            deferred.resolve({
+                etag: normalizeETag(data.ETag)
+            });
+        }, function () {
+            var err = errors.errorCodes.CACHE_NOT_FOUND;
+            deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+        });
+        return deferred.promise;
+    };
+
+    /**
      * Restores the cached data for the provided key.
      *
      * @example

--- a/lib/cacheInterface.js
+++ b/lib/cacheInterface.js
@@ -23,5 +23,5 @@
  */
 (function (module, interfaceFactory) {
     'use strict';
-    module.exports = interfaceFactory(['save', 'restore', 'remove', 'keys', 'set', 'exists']);
+    module.exports = interfaceFactory(['save', 'restore', 'remove', 'keys', 'set', 'exists', 'head']);
 }(module, require('./interfaceFactory')));

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -47,6 +47,28 @@
         checkHeader = options.checkHeader || checkHeader;
 
         return {
+            head: function (req, res) {
+                var key = options.keyFunc(req),
+                    ifNewerHash = req.headers[checkHeader];
+                cacheImpl.head(key).then(function (data) {
+                    res.header('etag', data.etag);
+                    if (data.etag !== ifNewerHash) {
+                        res.status(200).end();
+                    } else {
+                        res.status(304).end();
+                    }
+                }, function (reason) {
+                    if (reason) {
+                        if (reason.code === errors.errorCodes.CACHE_NOT_FOUND.code) {
+                            res.status(404).send(reason.message);
+                        } else {
+                            res.status(500).send(reason.message);
+                        }
+                    } else {
+                        res.status(500).send('An Unknown Error Occurred');
+                    }
+                });
+            },
             save: function (req, res) {
                 var dataToBeCached = JSON.stringify(req.body),
                     key = options.keyFunc(req),

--- a/lib/setImpl/mem.js
+++ b/lib/setImpl/mem.js
@@ -41,6 +41,10 @@
         return this.cache.save(dataToBeCached, key, hashToReplace);
     };
 
+    MemSet.prototype.head = function (key) {
+        return this.cache.head(key);
+    };
+
     MemSet.prototype.restore = function (key, ifNewerHash) {
         return this.cache.restore(key, ifNewerHash);
     };

--- a/lib/setInterface.js
+++ b/lib/setInterface.js
@@ -23,5 +23,5 @@
  */
 (function (module, interfaceFactory) {
     'use strict';
-    module.exports = interfaceFactory(['save', 'restore', 'remove', 'keys', 'destroy', 'exists']);
+    module.exports = interfaceFactory(['save', 'restore', 'remove', 'keys', 'destroy', 'exists', 'head']);
 }(module, require('./interfaceFactory')));

--- a/test/handler.js
+++ b/test/handler.js
@@ -85,7 +85,6 @@
                 },
                 new MockResponse(function (res) {
                     try {
-
                         expect(res.headers.etag).to.equal('4cdbc5ffe38a19ec2fd3c1625f92c14e2e0b4ec0');
                         expect(res.statusCode).to.equal(200);
                         done();
@@ -205,6 +204,9 @@
                 new MockResponse(function () {
                     cache.restore({headers: {}}, new MockResponse(function (res) {
                         try {
+                            expect(res.body).to.equal(JSON.stringify({
+                                name: 'Zul'
+                            }));
                             expect(res.headers.etag).to.equal('4cdbc5ffe38a19ec2fd3c1625f92c14e2e0b4ec0');
                             expect(res.statusCode).to.equal(200);
                             done();
@@ -280,6 +282,81 @@
                 }
             );
             cache.restore({headers: {'if-none-match': 'test-hash'}}, new MockResponse(function (res) {
+                try {
+                    expect(res.body).to.equal('Cache for [test-restore-no-exist] not found');
+                    expect(res.statusCode).to.equal(404);
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            }));
+        });
+
+        it('Should be able to head a cached value', function (done) {
+            var cache = lib.handler(lib.cache('mem', {}),
+                {
+                    keyFunc: function () {
+                        return 'test';
+                    }
+                }
+            );
+            cache.save(
+                {
+                    body: {
+                        name: 'Zul'
+                    },
+                    headers: {}
+                },
+                new MockResponse(function () {
+                    cache.head({headers: {}}, new MockResponse(function (res) {
+                        try {
+                            expect(res.headers.etag).to.equal('4cdbc5ffe38a19ec2fd3c1625f92c14e2e0b4ec0');
+                            expect(res.statusCode).to.equal(200);
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }));
+                })
+            );
+        });
+        it('Should be able to head a cached value for the same version', function (done) {
+            var cache = lib.handler(lib.cache('mem', {}),
+                {
+                    keyFunc: function () {
+                        return 'test';
+                    }
+                }
+            );
+            cache.save(
+                {
+                    body: {
+                        name: 'Zul'
+                    },
+                    headers: {}
+                },
+                new MockResponse(function () {
+                    cache.head({headers: {'if-none-match': '4cdbc5ffe38a19ec2fd3c1625f92c14e2e0b4ec0'}}, new MockResponse(function (res) {
+                        try {
+                            expect(res.headers.etag).to.equal('4cdbc5ffe38a19ec2fd3c1625f92c14e2e0b4ec0');
+                            expect(res.statusCode).to.equal(304);
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }));
+                })
+            );
+        });
+        it('Shouldn\'t head if a value doesn\'t exist', function (done) {
+            var cache = lib.handler(lib.cache('mem', {}),
+                {
+                    keyFunc: function () {
+                        return 'test-restore-no-exist';
+                    }
+                }
+            );
+            cache.head({headers: {}}, new MockResponse(function (res) {
                 try {
                     expect(res.body).to.equal('Cache for [test-restore-no-exist] not found');
                     expect(res.statusCode).to.equal(404);
@@ -392,5 +469,8 @@
             this.body = value;
             cb(this);
         };
+        this.end = function() {
+            cb(this);
+        }
     }
 }(require('./chaiPromise').expect, require('../index'), require('../lib/cacheInterface')));

--- a/test/handler.js
+++ b/test/handler.js
@@ -469,7 +469,7 @@
             this.body = value;
             cb(this);
         };
-        this.end = function() {
+        this.end = function () {
             cb(this);
         };
     }

--- a/test/handler.js
+++ b/test/handler.js
@@ -471,6 +471,6 @@
         };
         this.end = function() {
             cb(this);
-        }
+        };
     }
 }(require('./chaiPromise').expect, require('../index'), require('../lib/cacheInterface')));

--- a/test/impls.js
+++ b/test/impls.js
@@ -388,6 +388,20 @@
                         });
                     });
                 });
+                it('Should be able to head a cached value', function () {
+                    return testConfig.createCache().then(function (cache) {
+                        return cache.save(JSON.stringify(testConfig.dataToSave), 'head-test').then(function (data) {
+                            return expect(cache.head('head-test')).to.eventually.deep.equal({
+                                etag: data.etag
+                            });
+                        });
+                    });
+                });
+                it('Shouldn\'t head an object if a value doesn\'t exist', function () {
+                    return testConfig.createCache().then(function (cache) {
+                        return expect(cache.head('doesnt-exist')).to.eventually.be.rejectedWith(errors.CacheError, util.format(errors.errorCodes.CACHE_NOT_FOUND.message, 'doesnt-exist'));
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
This PR adds the ability for metadata to be retrieved about a cache key. Currently, this only supports retrieving the `etag` of the cached data for synchronization purposes. This also exposes the same functionality through the handler so that it can be used easily through an API.