### PR TITLE
Simplify Dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@
             setClass = require(setModule);
         }
         catch (err) {
-            console.warn('Implementation [%s] does not provide a set class. Set Functionality is not required but is recommended', impl);
+            console.warn('Unable to load Set class for Implementation [%s]. Set Functionality is not required but is recommended.', impl, err);
         }
 
         try {

--- a/lib/cacheImpl/fs.js
+++ b/lib/cacheImpl/fs.js
@@ -175,18 +175,13 @@
      * @returns {Promise}
      */
     FSCache.prototype.head = function (key) {
-        var self = this,
-            urlEncodedKey = encodeURIComponent(key);
-
-        return new Promise(function (resolve, reject) {
-            self.readFileAsync(path.join(self.path, urlEncodedKey)).then(function (data) {
-                resolve({
-                    etag: getSHA1(data.toString())
-                });
-            }, function () {
-                var err = errors.errorCodes.CACHE_NOT_FOUND;
-                reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-            });
+        return this.readFileAsync(path.join(this.path, encodeURIComponent(key))).then(function (data) {
+            return {
+                etag: getSHA1(data.toString())
+            };
+        }, function () {
+            var err = errors.errorCodes.CACHE_NOT_FOUND;
+            throw new errors.CacheError(err.name, util.format(err.message, key), err.code);
         });
     };
 
@@ -208,28 +203,23 @@
      * @returns {Promise}
      */
     FSCache.prototype.restore = function (key, ifNewerHash) {
-        var self = this,
-            urlEncodedKey = encodeURIComponent(key);
-
-        return new Promise(function (resolve, reject) {
-            self.readFileAsync(path.join(self.path, urlEncodedKey)).then(function (data) {
-                data = data.toString();
-                var storedHash = getSHA1(data);
-                // If we were sent a hash, only return data if it doesn't match what is currently stored.
-                if (ifNewerHash && ifNewerHash === storedHash) {
-                    resolve({
-                        etag: storedHash
-                    });
-                } else {
-                    resolve({
-                        etag: storedHash,
-                        body: data
-                    });
-                }
-            }, function () {
-                var err = errors.errorCodes.CACHE_NOT_FOUND;
-                reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-            });
+        return this.readFileAsync(path.join(this.path, encodeURIComponent(key))).then(function (data) {
+            data = data.toString();
+            var storedHash = getSHA1(data);
+            // If we were sent a hash, only return data if it doesn't match what is currently stored.
+            if (ifNewerHash && ifNewerHash === storedHash) {
+                return {
+                    etag: storedHash
+                };
+            } else {
+                return {
+                    etag: storedHash,
+                    body: data
+                };
+            }
+        }, function () {
+            var err = errors.errorCodes.CACHE_NOT_FOUND;
+            throw new errors.CacheError(err.name, util.format(err.message, key), err.code);
         });
     };
 
@@ -324,12 +314,7 @@
      * @returns {Promise}
      */
     FSCache.prototype.keys = function () {
-        var self = this;
-        return new Promise(function (resolve) {
-            resolve(self.readdirAsync(self.path).then(function (files) {
-                return files.map(decodeURIComponent);
-            }));
-        });
+        return this.readdirAsync(this.path).map(decodeURIComponent);
     };
 
     /**
@@ -345,10 +330,9 @@
      * @returns {Promise}
      */
     FSCache.prototype.exists = function (key) {
-        var self = this,
-            urlEncodedKey = encodeURIComponent(key);
+        var self = this;
         return new Promise(function (resolve) {
-            self.xfs.exists(path.join(self.path, urlEncodedKey), function (exists) {
+            self.xfs.exists(path.join(self.path, encodeURIComponent(key)), function (exists) {
                 resolve(exists);
             });
         });

--- a/lib/cacheImpl/fs.js
+++ b/lib/cacheImpl/fs.js
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-(function (module, cacheInterface, inherit, util, fs, path, Promise, JSSHA, errors, fsWishlist) {
+(function (module, cacheInterface, inherit, util, fs, path, Promise, crypto, errors, fsWishlist) {
     'use strict';
     var requiredArgs = [
         {
@@ -60,12 +60,12 @@
 
         self.xfs = fsWishlist.mixin(self.xfs);
 
+        self.xfs.mkdirp(self.path);
+
         self.readFileAsync = Promise.promisify(self.xfs.readFile);
         self.writeFileAsync = Promise.promisify(self.xfs.writeFile);
         self.unlinkAsync = Promise.promisify(self.xfs.unlink);
         self.readdirAsync = Promise.promisify(self.xfs.readdir);
-
-        self.xfs.mkdirp(self.path);
 
         this.getOrCreateSet = function getOrCreateSet(key) {
             if (FSCache.Set) {
@@ -355,8 +355,8 @@
     };
 
     var getSHA1 = function (data) {
-        return new JSSHA(data, 'TEXT').getHash('SHA-1', 'HEX');
+        return crypto.createHash('sha1').update(data).digest('hex');
     };
 
     module.exports = FSCache;
-}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('fs'), require('path'), require('bluebird'), require('jssha'), require('../errors'), require('fs-wishlist')));
+}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('fs'), require('path'), require('bluebird'), require('crypto'), require('../errors'), require('fs-wishlist')));

--- a/lib/cacheImpl/fs.js
+++ b/lib/cacheImpl/fs.js
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-(function (module, cacheInterface, inherit, util, fs, path, mkdirp, Q, cbQ, JSSHA, errors, process) {
+(function (module, cacheInterface, inherit, util, fs, path, Promise, JSSHA, errors, fsWishlist) {
     'use strict';
     var requiredArgs = [
         {
@@ -58,37 +58,33 @@
 
         self.xfs = options.fs || fs;
 
-        mkdirp.sync(self.path, {
-            fs: self.xfs
-        });
+        self.xfs = fsWishlist.mixin(self.xfs);
+
+        self.readFileAsync = Promise.promisify(self.xfs.readFile);
+        self.writeFileAsync = Promise.promisify(self.xfs.writeFile);
+        self.unlinkAsync = Promise.promisify(self.xfs.unlink);
+        self.readdirAsync = Promise.promisify(self.xfs.readdir);
+
+        self.xfs.mkdirp(self.path);
 
         this.getOrCreateSet = function getOrCreateSet(key) {
             if (FSCache.Set) {
-                return key in sets ? sets[key] : sets[key] = (function (key) {
-                    var deferred = Q.defer(),
-                        setInstance;
-                    process.nextTick(function () {
-                        try {
-                            setInstance = new FSCache.Set(key, self);
-                            setInstance.on('destroy', function () {
-                                delete sets[key];
-                            });
-                            setInstance.on('error', function (err) {
-                                delete sets[key];
-                                deferred.reject(err);
-                            });
-                            setInstance.on('ready', function () {
-                                deferred.resolve(setInstance);
-                            });
-                        } catch (err) {
-                            deferred.reject(err);
-                        }
+                return key in sets ? sets[key] : sets[key] = new Promise(function (resolve, reject) {
+                    var setInstance = new FSCache.Set(key, self);
+                    setInstance.on('destroy', function () {
+                        delete sets[key];
                     });
-                    return deferred.promise;
-                }(key));
+                    setInstance.on('error', function (err) {
+                        delete sets[key];
+                        reject(err);
+                    });
+                    setInstance.on('ready', function () {
+                        resolve(setInstance);
+                    });
+                });
             }
             var err = errors.errorCodes.SET_NOT_DEFINED;
-            return Q.reject(new errors.CacheError(err.name, err.message, err.code));
+            return Promise.reject(new errors.CacheError(err.name, err.message, err.code));
         };
 
     }
@@ -111,64 +107,55 @@
      * @param dataToBeCached `String`. **Required**. The data to be stored
      * @param key `String`. **Required**. Identifies the data being stored, used later to retrieve, update, or restore the cache
      * @param hashToReplace `String` _Optional_ If provided, only updates the cache when the hash value provided is the same as what is currently stored. If there isn't a cache currently created it will persist the data regardless.
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     FSCache.prototype.save = function (dataToBeCached, key, hashToReplace) {
         var self = this,
-            urlEncodedKey = encodeURIComponent(key),
-            deferred = Q.defer(),
-            readFile,
-            writeFile;
-        // If we were sent a hash, we only want to update the cache if the hash matches what is currently stored.
-        if (hashToReplace) {
-            readFile = cbQ.cb();
-            self.xfs.readFile(path.join(self.path, urlEncodedKey), readFile);
-            readFile.promise.then(function (data) {
-                var storedHash = getSHA1(data.toString());
-                // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
-                if (storedHash !== hashToReplace) {
-                    var err = errors.errorCodes.HASH_MISMATCH;
-                    deferred.reject(new errors.CacheError(err.name, util.format(err.message, hashToReplace, storedHash), err.code));
-                } else {
-                    // Otherwise hashes match, so go ahead and update the cache.
-                    writeFile = cbQ.cb();
-                    self.xfs.writeFile(path.join(self.path, urlEncodedKey), dataToBeCached, writeFile);
-                    writeFile.promise.then(function () {
-                        deferred.resolve({
+            urlEncodedKey = encodeURIComponent(key);
+
+        return new Promise(function (resolve, reject) {
+            // If we were sent a hash, we only want to update the cache if the hash matches what is currently stored.
+            if (hashToReplace) {
+                self.readFileAsync(path.join(self.path, urlEncodedKey)).then(function (data) {
+                    var storedHash = getSHA1(data.toString());
+                    // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
+                    if (storedHash !== hashToReplace) {
+                        var err = errors.errorCodes.HASH_MISMATCH;
+                        reject(new errors.CacheError(err.name, util.format(err.message, hashToReplace, storedHash), err.code));
+                    } else {
+                        // Otherwise hashes match, so go ahead and update the cache.
+                        self.writeFileAsync(path.join(self.path, urlEncodedKey), dataToBeCached).then(function () {
+                            resolve({
+                                etag: getSHA1(dataToBeCached)
+                            });
+                        }, function (reason) {
+                            var err = errors.errorCodes.UPDATE_FAILED;
+                            reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + reason, err.code));
+                        });
+                    }
+                }, function () {
+                    // If we try to update a key that doesn't exist, update it anyways.
+                    self.writeFileAsync(path.join(self.path, urlEncodedKey), dataToBeCached).then(function () {
+                        resolve({
                             etag: getSHA1(dataToBeCached)
                         });
                     }, function (reason) {
                         var err = errors.errorCodes.UPDATE_FAILED;
-                        deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + reason, err.code));
+                        reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + reason, err.code));
                     });
-                }
-            }, function () {
-                // If we try to update a key that doesn't exist, update it anyways.
-                writeFile = cbQ.cb();
-                self.xfs.writeFile(path.join(self.path, urlEncodedKey), dataToBeCached, writeFile);
-                writeFile.promise.then(function () {
-                    deferred.resolve({
+                });
+            } else {
+                // We didn't receive a previous hash, so update the cache blindly.
+                self.writeFileAsync(path.join(self.path, urlEncodedKey), dataToBeCached).then(function () {
+                    resolve({
                         etag: getSHA1(dataToBeCached)
                     });
                 }, function (reason) {
                     var err = errors.errorCodes.UPDATE_FAILED;
-                    deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + reason, err.code));
+                    reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + reason, err.code));
                 });
-            });
-        } else {
-            // We didn't receive a previous hash, so update the cache blindly.
-            writeFile = cbQ.cb();
-            self.xfs.writeFile(path.join(self.path, urlEncodedKey), dataToBeCached, writeFile);
-            writeFile.promise.then(function () {
-                deferred.resolve({
-                    etag: getSHA1(dataToBeCached)
-                });
-            }, function (reason) {
-                var err = errors.errorCodes.UPDATE_FAILED;
-                deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + reason, err.code));
-            });
-        }
-        return deferred.promise;
+            }
+        });
     };
 
     /**
@@ -185,24 +172,22 @@
      * ```
      *
      * @param key `String`. **Required**. Identifies the data being retrieved
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     FSCache.prototype.head = function (key) {
         var self = this,
-            urlEncodedKey = encodeURIComponent(key),
-            deferred = Q.defer(),
-            readFile = cbQ.cb();
+            urlEncodedKey = encodeURIComponent(key);
 
-        self.xfs.readFile(path.join(self.path, urlEncodedKey), readFile);
-        readFile.promise.then(function (data) {
-            deferred.resolve({
-                etag: getSHA1(data.toString())
+        return new Promise(function (resolve, reject) {
+            self.readFileAsync(path.join(self.path, urlEncodedKey)).then(function (data) {
+                resolve({
+                    etag: getSHA1(data.toString())
+                });
+            }, function () {
+                var err = errors.errorCodes.CACHE_NOT_FOUND;
+                reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
             });
-        }, function () {
-            var err = errors.errorCodes.CACHE_NOT_FOUND;
-            deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
         });
-        return deferred.promise;
     };
 
     /**
@@ -220,34 +205,32 @@
      *
      * @param key `String`. **Required**. Identifies the data being retrieved
      * @param ifNewerHash `String`. _Optional_. If provided only retrieves the cached data if the hashes do not match, otherwise it just retrieves everything
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     FSCache.prototype.restore = function (key, ifNewerHash) {
         var self = this,
-            urlEncodedKey = encodeURIComponent(key),
-            deferred = Q.defer(),
-            readFile = cbQ.cb();
+            urlEncodedKey = encodeURIComponent(key);
 
-        self.xfs.readFile(path.join(self.path, urlEncodedKey), readFile);
-        readFile.promise.then(function (data) {
-            data = data.toString();
-            var storedHash = getSHA1(data);
-            // If we were sent a hash, only return data if it doesn't match what is currently stored.
-            if (ifNewerHash && ifNewerHash === storedHash) {
-                deferred.resolve({
-                    etag: storedHash
-                });
-            } else {
-                deferred.resolve({
-                    etag: storedHash,
-                    body: data
-                });
-            }
-        }, function () {
-            var err = errors.errorCodes.CACHE_NOT_FOUND;
-            deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+        return new Promise(function (resolve, reject) {
+            self.readFileAsync(path.join(self.path, urlEncodedKey)).then(function (data) {
+                data = data.toString();
+                var storedHash = getSHA1(data);
+                // If we were sent a hash, only return data if it doesn't match what is currently stored.
+                if (ifNewerHash && ifNewerHash === storedHash) {
+                    resolve({
+                        etag: storedHash
+                    });
+                } else {
+                    resolve({
+                        etag: storedHash,
+                        body: data
+                    });
+                }
+            }, function () {
+                var err = errors.errorCodes.CACHE_NOT_FOUND;
+                reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+            });
         });
-        return deferred.promise;
     };
 
     /**
@@ -265,50 +248,45 @@
      *
      * @param key `String`. **Required**. Identifies the data being deleted
      * @param hashToDelete `String`. _Optional_. If provided only deletes the cache if the hashes match, otherwise it just deletes the cache
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     FSCache.prototype.remove = function (key, hashToDelete) {
         var self = this,
-            urlEncodedKey = encodeURIComponent(key),
-            deferred = Q.defer(),
-            readFile = cbQ.cb(),
-            removeFile = cbQ.cb();
+            urlEncodedKey = encodeURIComponent(key);
 
-        self.xfs.readFile(path.join(self.path, urlEncodedKey), readFile);
-        readFile.promise.then(function (data) {
-            if (hashToDelete) {
-                var storedHash = getSHA1(data.toString());
-                // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
-                if (storedHash !== hashToDelete) {
-                    var err = errors.errorCodes.HASH_MISMATCH;
-                    deferred.reject(new errors.CacheError(err.name, util.format(err.message, hashToDelete, storedHash), err.code));
+        return new Promise(function (resolve, reject) {
+            self.readFileAsync(path.join(self.path, urlEncodedKey)).then(function (data) {
+                if (hashToDelete) {
+                    var storedHash = getSHA1(data.toString());
+                    // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
+                    if (storedHash !== hashToDelete) {
+                        var err = errors.errorCodes.HASH_MISMATCH;
+                        reject(new errors.CacheError(err.name, util.format(err.message, hashToDelete, storedHash), err.code));
+                    } else {
+                        // Otherwise hashes match, so go ahead and delete the cache.
+                        self.unlinkAsync(path.join(self.path, urlEncodedKey)).then(function () {
+                            resolve();
+                        }, function (reason) {
+                            var err = errors.errorCodes.DELETE_FAILED;
+                            reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' +
+                            reason, err.code));
+                        });
+                    }
                 } else {
-                    // Otherwise hashes match, so go ahead and delete the cache.
-                    self.xfs.unlink(path.join(self.path, urlEncodedKey), removeFile);
-                    removeFile.promise.then(function () {
-                        deferred.resolve();
+                    // We didn't receive a previous hash, so delete the cache blindly.
+                    self.unlinkAsync(path.join(self.path, urlEncodedKey)).then(function () {
+                        resolve();
                     }, function (reason) {
                         var err = errors.errorCodes.DELETE_FAILED;
-                        deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' +
+                        reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' +
                         reason, err.code));
                     });
                 }
-            } else {
-                // We didn't receive a previous hash, so delete the cache blindly.
-                self.xfs.unlink(path.join(self.path, urlEncodedKey), removeFile);
-                removeFile.promise.then(function () {
-                    deferred.resolve();
-                }, function (reason) {
-                    var err = errors.errorCodes.DELETE_FAILED;
-                    deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' +
-                    reason, err.code));
-                });
-            }
-        }, function () {
-            var err = errors.errorCodes.CACHE_NOT_FOUND;
-            deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+            }, function () {
+                var err = errors.errorCodes.CACHE_NOT_FOUND;
+                reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+            });
         });
-        return deferred.promise;
     };
 
     /**
@@ -325,7 +303,7 @@
     FSCache.prototype.set = function (setKey) {
         if (!setKey) {
             var err = new Error(util.format('Invalid Argument Type Expected [%s] for [%s] but got [%s]', 'string', 'setKey', typeof setKey));
-            return Q.reject(err);
+            return Promise.reject(err);
         }
         return this.getOrCreateSet(setKey);
     };
@@ -343,13 +321,14 @@
      * });
      * ```
      *
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     FSCache.prototype.keys = function () {
-        var readDir = cbQ.cb();
-        this.xfs.readdir(this.path, readDir);
-        return readDir.promise.then(function (files) {
-            return files.map(decodeURIComponent);
+        var self = this;
+        return new Promise(function (resolve) {
+            resolve(self.readdirAsync(self.path).then(function (files) {
+                return files.map(decodeURIComponent);
+            }));
         });
     };
 
@@ -363,16 +342,16 @@
      * })
      * ```
      * @param {string} key - key value used for cached item
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     FSCache.prototype.exists = function (key) {
-        var deferred = Q.defer(),
-            self = this,
+        var self = this,
             urlEncodedKey = encodeURIComponent(key);
-        self.xfs.exists(path.join(self.path, urlEncodedKey), function (exists) {
-            deferred.resolve(exists);
+        return new Promise(function (resolve) {
+            self.xfs.exists(path.join(self.path, urlEncodedKey), function (exists) {
+                resolve(exists);
+            });
         });
-        return deferred.promise;
     };
 
     var getSHA1 = function (data) {
@@ -380,4 +359,4 @@
     };
 
     module.exports = FSCache;
-}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('fs'), require('path'), require('mkdirp'), require('q'), require('cb-q'), require('jssha'), require('../errors'), process));
+}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('fs'), require('path'), require('bluebird'), require('jssha'), require('../errors'), require('fs-wishlist')));

--- a/lib/cacheImpl/mem.js
+++ b/lib/cacheImpl/mem.js
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-(function (module, cacheInterface, inherit, util, Promise, errors, JSSHA) {
+(function (module, cacheInterface, inherit, util, Promise, errors, crypto) {
     'use strict';
     function Cache() {
         var cache = {};
@@ -321,8 +321,8 @@
     };
 
     var getSHA1 = function (data) {
-        return new JSSHA(data, 'TEXT').getHash('SHA-1', 'HEX');
+        return crypto.createHash('sha1').update(data).digest('hex');
     };
 
     module.exports = TestCache;
-}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('bluebird'), require('../errors'), require('jssha')));
+}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('bluebird'), require('../errors'), require('crypto')));

--- a/lib/cacheImpl/mem.js
+++ b/lib/cacheImpl/mem.js
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-(function (module, cacheInterface, inherit, util, Q, errors, JSSHA, process) {
+(function (module, cacheInterface, inherit, util, Promise, errors, JSSHA) {
     'use strict';
     function Cache() {
         var cache = {};
@@ -33,7 +33,7 @@
             cache[key] = value;
         };
 
-        this.delete = function (key) {
+        this.remove = function (key) {
             delete cache[key];
         };
 
@@ -79,12 +79,12 @@
      * @param dataToBeCached `String`. **Required**. The data to be stored
      * @param key `String`. **Required**. Identifies the data being stored, used later to retrieve, update, or restore the cache
      * @param hashToReplace `String` _Optional_ If provided, only updates the cache when the hash value provided is the same as what is currently stored. If there isn't a cache currently created it will persist the data regardless.
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     TestCache.prototype.save = function (dataToBeCached, key, hashToReplace) {
-        var deferred = Q.defer(),
-            self = this;
-        process.nextTick(function () {
+        var self = this;
+
+        return new Promise(function (resolve, reject) {
             // If we were sent a hash, we only want to update the cache if the hash matches what is currently stored.
             var data = self.cache.get(key);
             if (hashToReplace) {
@@ -94,21 +94,21 @@
                         body: dataToBeCached
                     };
                     self.cache.set(key, data);
-                    deferred.resolve({
+                    resolve({
                         etag: data.hash
                     });
                 } else {
                     var storedHash = data.hash;
                     if (storedHash !== hashToReplace) {
                         var err = errors.errorCodes.HASH_MISMATCH;
-                        deferred.reject(new errors.CacheError(err.name, util.format(err.message, hashToReplace, storedHash), err.code));
+                        reject(new errors.CacheError(err.name, util.format(err.message, hashToReplace, storedHash), err.code));
                     } else {
                         data = {
                             hash: getSHA1(dataToBeCached),
                             body: dataToBeCached
                         };
                         self.cache.set(key, data);
-                        deferred.resolve({
+                        resolve({
                             etag: data.hash
                         });
                     }
@@ -120,12 +120,11 @@
                     body: dataToBeCached
                 };
                 self.cache.set(key, data);
-                deferred.resolve({
+                resolve({
                     etag: data.hash
                 });
             }
         });
-        return deferred.promise;
     };
 
     /**
@@ -142,24 +141,22 @@
      * ```
      *
      * @param key `String`. **Required**. Identifies the data being retrieved
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     TestCache.prototype.head = function (key) {
-        var deferred = Q.defer(),
-            self = this;
+        var self = this;
 
-        process.nextTick(function () {
+        return new Promise(function (resolve, reject) {
             var data = self.cache.get(key);
             if (data) {
-                deferred.resolve({
+                resolve({
                     etag: data.hash
                 });
             } else {
                 var err = errors.errorCodes.CACHE_NOT_FOUND;
-                deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+                reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
             }
         });
-        return deferred.promise;
     };
 
     /**
@@ -177,33 +174,31 @@
      *
      * @param key `String`. **Required**. Identifies the data being retrieved
      * @param ifNewerHash `String`. _Optional_. If provided only retrieves the cached data if the hashes do not match, otherwise it just retrieves everything
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     TestCache.prototype.restore = function (key, ifNewerHash) {
-        var deferred = Q.defer(),
-            self = this;
+        var self = this;
 
-        process.nextTick(function () {
+        return new Promise(function (resolve, reject) {
             var data = self.cache.get(key);
             if (data) {
                 var storedHash = data.hash;
                 // If we were sent a hash, only return data if it doesn't match what is currently stored.
                 if (ifNewerHash && ifNewerHash === storedHash) {
-                    deferred.resolve({
+                    resolve({
                         etag: storedHash
                     });
                 } else {
-                    deferred.resolve({
+                    resolve({
                         etag: storedHash,
                         body: data.body
                     });
                 }
             } else {
                 var err = errors.errorCodes.CACHE_NOT_FOUND;
-                deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+                reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
             }
         });
-        return deferred.promise;
     };
 
     /**
@@ -221,14 +216,13 @@
      *
      * @param key `String`. **Required**. Identifies the data being deleted
      * @param hashToDelete `String`. _Optional_. If provided only deletes the cache if the hashes match, otherwise it just deletes the cache
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     TestCache.prototype.remove = function (key, hashToDelete) {
-        var deferred = Q.defer(),
-            self = this,
+        var self = this,
             err;
 
-        process.nextTick(function () {
+        return new Promise(function (resolve, reject) {
             var data = self.cache.get(key);
             if (data) {
                 if (hashToDelete) {
@@ -236,23 +230,22 @@
                     // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
                     if (storedHash !== hashToDelete) {
                         err = errors.errorCodes.HASH_MISMATCH;
-                        deferred.reject(new errors.CacheError(err.name, util.format(err.message, hashToDelete, storedHash), err.code));
+                        reject(new errors.CacheError(err.name, util.format(err.message, hashToDelete, storedHash), err.code));
                     } else {
                         // Otherwise hashes match, so go ahead and delete the cache.
-                        self.cache.delete(key);
-                        deferred.resolve();
+                        self.cache.remove(key);
+                        resolve();
                     }
                 } else {
                     // We didn't receive a previous hash, so delete the cache blindly.
-                    self.cache.delete(key);
-                    deferred.resolve();
+                    self.cache.remove(key);
+                    resolve();
                 }
             } else {
                 err = errors.errorCodes.CACHE_NOT_FOUND;
-                deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+                reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
             }
         });
-        return deferred.promise;
     };
 
     /**
@@ -268,26 +261,24 @@
      * });
      * ```
      *
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     TestCache.prototype.keys = function () {
-        var deferred = Q.defer(),
-            self = this;
-        process.nextTick(function () {
-            deferred.resolve(self.cache.keys());
+        var self = this;
+        return new Promise(function (resolve) {
+            resolve(self.cache.keys());
         });
-        return deferred.promise;
     };
 
     /**
      * Create an instance of a cache set if one exists else it returns a cached cacheSet
      * @param {string} key - key value used for the cache set
-     * @returns {MemSet}
+     * @returns {TestCache}
      */
     TestCache.prototype.set = function (key) {
         if (!TestCache.Set) {
             var err = errors.errorCodes.SET_NOT_DEFINED;
-            return Q.reject(new errors.CacheError(err.name, err.message, err.code));
+            return Promise.reject(new errors.CacheError(err.name, err.message, err.code));
         }
         var set = this.cache.get(key),
             self = this;
@@ -295,20 +286,15 @@
             return set;
         } else {
             set = (function (key) {
-                var deferred = Q.defer(),
-                    setInstance;
-                try {
-                    setInstance = new TestCache.Set(key, self);
+                return new Promise(function (resolve) {
+                    var setInstance = new TestCache.Set(key, self);
                     setInstance.on('destroy', function () {
-                        self.cache.delete(key);
+                        self.cache.remove(key);
                     });
                     setInstance.on('ready', function () {
-                        deferred.resolve(setInstance);
+                        resolve(setInstance);
                     });
-                } catch (err) {
-                    deferred.reject(err);
-                }
-                return deferred.promise;
+                });
             }(key));
             self.cache.set(key, set);
         }
@@ -325,15 +311,13 @@
      * })
      * ```
      * @param {string} key - key value used for cached item
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     TestCache.prototype.exists = function (key) {
-        var deferred = Q.defer(),
-            self = this;
-        process.nextTick(function () {
-            deferred.resolve(self.cache.exists(key));
+        var self = this;
+        return new Promise(function (resolve) {
+            resolve(self.cache.exists(key));
         });
-        return deferred.promise;
     };
 
     var getSHA1 = function (data) {
@@ -341,4 +325,4 @@
     };
 
     module.exports = TestCache;
-}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('q'), require('../errors'), require('jssha'), process));
+}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('bluebird'), require('../errors'), require('jssha')));

--- a/lib/cacheImpl/redis.js
+++ b/lib/cacheImpl/redis.js
@@ -71,6 +71,12 @@
         self.redisClient = redis.createClient(self.port, self.host, self.options);
         self.redisClient.getKeys = self.redisClient.keys.bind(self.redisClient, '*');
 
+        self.getAsync = Promise.promisify(self.redisClient.get).bind(self.redisClient);
+        self.getKeysAsync = Promise.promisify(self.redisClient.getKeys).bind(self.redisClient);
+        self.setAsync = Promise.promisify(self.redisClient.set).bind(self.redisClient);
+        self.delAsync = Promise.promisify(self.redisClient.del).bind(self.redisClient);
+        self.existsAsync = Promise.promisify(self.redisClient.exists).bind(self.redisClient);
+
         self.redisClient.on('error', function (err) {
             self.emit('error', err);
         });
@@ -119,56 +125,33 @@
      * @returns {Promise}
      */
     RedisCache.prototype.save = function (dataToBeCached, key, hashToReplace) {
-        var self = this;
-        return new Promise(function (resolve, reject) {
-            // If we were sent a hash, we only want to update the cache if the hash matches what is currently stored.
-            if (hashToReplace) {
-                self.redisClient.get(key, function (redisErr, data) {
-                    if (redisErr || !data) {
-                        // If we try to update a key that doesn't exist, update it anyways.
-                        self.redisClient.set(key, dataToBeCached, function (redisErr) {
-                            if (redisErr) {
-                                var err = errors.errorCodes.UPDATE_FAILED;
-                                return reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + redisErr, err.code));
-                            }
-
-                            resolve({
-                                etag: getSHA1(dataToBeCached)
-                            });
-                        });
+        var self = this,
+            savePromise;
+        // If we were sent a hash, we only want to update the cache if the hash matches what is currently stored.
+        if (hashToReplace) {
+            savePromise = self.getAsync(key).then(function (data) {
+                if (!data) {
+                    // If we try to update a key that doesn't exist, update it anyways.
+                    return self.setAsync(key, dataToBeCached);
+                } else {
+                    var storedHash = getSHA1(data);
+                    // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
+                    if (storedHash !== hashToReplace) {
+                        var err = errors.errorCodes.HASH_MISMATCH;
+                        throw new errors.CacheError(err.name, util.format(err.message, hashToReplace, storedHash), err.code);
                     } else {
-                        var storedHash = getSHA1(data);
-                        // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
-                        if (storedHash !== hashToReplace) {
-                            var err = errors.errorCodes.HASH_MISMATCH;
-                            reject(new errors.CacheError(err.name, util.format(err.message, hashToReplace, storedHash), err.code));
-                        } else {
-                            // Otherwise hashes match, so go ahead and update the cache.
-                            self.redisClient.set(key, dataToBeCached, function (redisErr) {
-                                if (redisErr) {
-                                    var err = errors.errorCodes.UPDATE_FAILED;
-                                    return reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + redisErr, err.code));
-                                }
-                                resolve({
-                                    etag: getSHA1(dataToBeCached)
-                                });
-                            });
-                        }
+                        // Otherwise hashes match, so go ahead and update the cache.
+                        return self.setAsync(key, dataToBeCached);
                     }
-                });
-            } else {
-                // We didn't receive a previous hash, so update the cache blindly.
-                self.redisClient.set(key, dataToBeCached, function (redisErr) {
-                    if (redisErr) {
-                        var err = errors.errorCodes.UPDATE_FAILED;
-                        return reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-                    }
+                }
+            });
+        } else {
+            // We didn't receive a previous hash, so update the cache blindly.
+            savePromise = self.setAsync(key, dataToBeCached);
+        }
 
-                    resolve({
-                        etag: getSHA1(dataToBeCached)
-                    });
-                });
-            }
+        return savePromise.return({
+            etag: getSHA1(dataToBeCached)
         });
     };
 
@@ -189,19 +172,15 @@
      * @returns {Promise}
      */
     RedisCache.prototype.head = function (key) {
-        var self = this;
+        return this.getAsync(key).then(function (data) {
+            if (!data) {
+                var err = errors.errorCodes.CACHE_NOT_FOUND;
+                throw new errors.CacheError(err.name, util.format(err.message, key), err.code);
+            }
 
-        return new Promise(function (resolve, reject) {
-            self.redisClient.get(key, function (redisErr, data) {
-                if (redisErr || !data) {
-                    var err = errors.errorCodes.CACHE_NOT_FOUND;
-                    return reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-                }
-
-                resolve({
-                    etag: getSHA1(data)
-                });
-            });
+            return {
+                etag: getSHA1(data)
+            };
         });
     };
 
@@ -223,28 +202,22 @@
      * @returns {Promise}
      */
     RedisCache.prototype.restore = function (key, ifNewerHash) {
-        var self = this;
+        return this.getAsync(key).then(function (data) {
+            if (!data) {
+                var err = errors.errorCodes.CACHE_NOT_FOUND;
+                throw new errors.CacheError(err.name, util.format(err.message, key), err.code);
+            }
 
-        return new Promise(function (resolve, reject) {
-            self.redisClient.get(key, function (redisErr, data) {
-                if (redisErr || !data) {
-                    var err = errors.errorCodes.CACHE_NOT_FOUND;
-                    return reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-                }
-
-                var storedHash = getSHA1(data);
-                // If we were sent a hash, only return data if it doesn't match what is currently stored.
-                if (ifNewerHash && ifNewerHash === storedHash) {
-                    resolve({
-                        etag: storedHash
-                    });
-                } else {
-                    resolve({
-                        etag: storedHash,
-                        body: data
-                    });
-                }
-            });
+            var result = {
+                etag: getSHA1(data)
+            };
+            // If we were sent a hash, only return data if it doesn't match what is currently stored.
+            if (ifNewerHash && ifNewerHash === result.etag) {
+                return result;
+            } else {
+                result.body = data;
+                return result;
+            }
         });
     };
 
@@ -269,40 +242,26 @@
         var self = this,
             err;
 
-        return new Promise(function (resolve, reject) {
-            self.redisClient.get(key, function (redisErr, data) {
-                if (redisErr || !data) {
-                    err = errors.errorCodes.CACHE_NOT_FOUND;
-                    return reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-                }
+        return self.getAsync(key).then(function (data) {
+            if (!data) {
+                err = errors.errorCodes.CACHE_NOT_FOUND;
+                throw new errors.CacheError(err.name, util.format(err.message, key), err.code);
+            }
 
-                if (hashToDelete) {
-                    var storedHash = getSHA1(data);
-                    // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
-                    if (storedHash !== hashToDelete) {
-                        err = errors.errorCodes.HASH_MISMATCH;
-                        reject(new errors.CacheError(err.name, util.format(err.message, hashToDelete, storedHash), err.code));
-                    } else {
-                        // Otherwise hashes match, so go ahead and delete the cache.
-                        self.redisClient.del(key, function (redisErr) {
-                            if (redisErr) {
-                                var err = errors.errorCodes.DELETE_FAILED;
-                                return reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + redisErr, err.code));
-                            }
-                            resolve();
-                        });
-                    }
+            if (hashToDelete) {
+                var storedHash = getSHA1(data);
+                // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
+                if (storedHash !== hashToDelete) {
+                    err = errors.errorCodes.HASH_MISMATCH;
+                    throw new errors.CacheError(err.name, util.format(err.message, hashToDelete, storedHash), err.code);
                 } else {
-                    // We didn't receive a previous hash, so delete the cache blindly.
-                    self.redisClient.del(key, function (redisErr) {
-                        if (redisErr) {
-                            var err = errors.errorCodes.DELETE_FAILED;
-                            return reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-                        }
-                        resolve();
-                    });
+                    // Otherwise hashes match, so go ahead and delete the cache.
+                    return self.delAsync(key);
                 }
-            });
+            } else {
+                // We didn't receive a previous hash, so delete the cache blindly.
+                return self.redisClient.del(key);
+            }
         });
     };
 
@@ -322,15 +281,7 @@
      * @returns {Promise}
      */
     RedisCache.prototype.keys = function () {
-        var self = this;
-        return new Promise(function (resolve, reject) {
-            self.redisClient.getKeys(function (err, result) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve(result);
-            });
-        });
+        return this.getKeysAsync();
     };
 
     /**
@@ -361,14 +312,8 @@
      * @returns {Promise}
      */
     RedisCache.prototype.exists = function (key) {
-        var self = this;
-        return new Promise(function (resolve, reject) {
-            self.redisClient.exists(key, function (err, result) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve(result === 1); // Redis returns 0/1 not true/false. See: http://redis.io/commands/exists
-            });
+        return this.existsAsync(key).then(function (result) {
+            return result === 1; // Redis returns 0/1 not true/false. See: http://redis.io/commands/exists
         });
     };
 

--- a/lib/cacheImpl/redis.js
+++ b/lib/cacheImpl/redis.js
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 /* jshint maxparams: 10 */
-(function (module, cacheInterface, inherit, util, Promise, errors, JSSHA, EventEmitter, redis) {
+(function (module, cacheInterface, inherit, util, Promise, errors, crypto, EventEmitter, redis) {
     /* jshint maxparams: 4 */
     'use strict';
     var requiredArgs = [
@@ -373,9 +373,9 @@
     };
 
     var getSHA1 = function (data) {
-        return new JSSHA(data, 'TEXT').getHash('SHA-1', 'HEX');
+        return crypto.createHash('sha1').update(data).digest('hex');
     };
 
     module.exports = RedisCache;
-}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('bluebird'), require('../errors'), require('jssha'),
+}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('bluebird'), require('../errors'), require('crypto'),
     require('events').EventEmitter, require('redis')));

--- a/lib/cacheImpl/redis.js
+++ b/lib/cacheImpl/redis.js
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 /* jshint maxparams: 10 */
-(function (module, cacheInterface, inherit, util, Q, errors, JSSHA, EventEmitter, redis, process) {
+(function (module, cacheInterface, inherit, util, Promise, errors, JSSHA, EventEmitter, redis) {
     /* jshint maxparams: 4 */
     'use strict';
     var requiredArgs = [
@@ -77,33 +77,23 @@
 
         this.getOrCreateSet = function getOrCreateSet(key) {
             if (RedisCache.Set) {
-                return key in sets ? sets[key] : sets[key] = (function (key) {
-                    var deferred = Q.defer(),
-                        setInstance;
-                    process.nextTick(function () {
-                        try {
-                            setInstance = new RedisCache.Set(key, self);
-                            setInstance.on('destroy', function () {
-                                delete sets[key];
-                            });
-                            setInstance.on('error', function (err) {
-                                delete sets[key];
-                                deferred.reject(err);
-                            });
-                            setInstance.on('ready', function () {
-                                deferred.resolve(setInstance);
-                            });
-                        } catch (err) {
-                            deferred.reject(err);
-                        }
+                return key in sets ? sets[key] : sets[key] = new Promise(function (resolve, reject) {
+                    var setInstance = new RedisCache.Set(key, self);
+                    setInstance.on('destroy', function () {
+                        delete sets[key];
                     });
-                    return deferred.promise;
-                }(key));
+                    setInstance.on('error', function (err) {
+                        delete sets[key];
+                        reject(err);
+                    });
+                    setInstance.on('ready', function () {
+                        resolve(setInstance);
+                    });
+                });
             }
 
             var err = errors.errorCodes.SET_NOT_DEFINED;
-            return Q.reject(new errors.CacheError(err.name, err.message, err.code));
-
+            return Promise.reject(new errors.CacheError(err.name, err.message, err.code));
         };
 
     }
@@ -126,60 +116,60 @@
      * @param dataToBeCached `String`. **Required**. The data to be stored
      * @param key `String`. **Required**. Identifies the data being stored, used later to retrieve, update, or restore the cache
      * @param hashToReplace `String` _Optional_ If provided, only updates the cache when the hash value provided is the same as what is currently stored. If there isn't a cache currently created it will persist the data regardless.
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     RedisCache.prototype.save = function (dataToBeCached, key, hashToReplace) {
-        var self = this,
-            deferred = Q.defer();
-        // If we were sent a hash, we only want to update the cache if the hash matches what is currently stored.
-        if (hashToReplace) {
-            self.redisClient.get(key, function (redisErr, data) {
-                if (redisErr || !data) {
-                    // If we try to update a key that doesn't exist, update it anyways.
-                    self.redisClient.set(key, dataToBeCached, function (redisErr) {
-                        if (redisErr) {
-                            var err = errors.errorCodes.UPDATE_FAILED;
-                            return deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + redisErr, err.code));
-                        }
-
-                        deferred.resolve({
-                            etag: getSHA1(dataToBeCached)
-                        });
-                    });
-                } else {
-                    var storedHash = getSHA1(data);
-                    // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
-                    if (storedHash !== hashToReplace) {
-                        var err = errors.errorCodes.HASH_MISMATCH;
-                        deferred.reject(new errors.CacheError(err.name, util.format(err.message, hashToReplace, storedHash), err.code));
-                    } else {
-                        // Otherwise hashes match, so go ahead and update the cache.
+        var self = this;
+        return new Promise(function (resolve, reject) {
+            // If we were sent a hash, we only want to update the cache if the hash matches what is currently stored.
+            if (hashToReplace) {
+                self.redisClient.get(key, function (redisErr, data) {
+                    if (redisErr || !data) {
+                        // If we try to update a key that doesn't exist, update it anyways.
                         self.redisClient.set(key, dataToBeCached, function (redisErr) {
                             if (redisErr) {
                                 var err = errors.errorCodes.UPDATE_FAILED;
-                                return deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + redisErr, err.code));
+                                return reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + redisErr, err.code));
                             }
-                            deferred.resolve({
+
+                            resolve({
                                 etag: getSHA1(dataToBeCached)
                             });
                         });
+                    } else {
+                        var storedHash = getSHA1(data);
+                        // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
+                        if (storedHash !== hashToReplace) {
+                            var err = errors.errorCodes.HASH_MISMATCH;
+                            reject(new errors.CacheError(err.name, util.format(err.message, hashToReplace, storedHash), err.code));
+                        } else {
+                            // Otherwise hashes match, so go ahead and update the cache.
+                            self.redisClient.set(key, dataToBeCached, function (redisErr) {
+                                if (redisErr) {
+                                    var err = errors.errorCodes.UPDATE_FAILED;
+                                    return reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + redisErr, err.code));
+                                }
+                                resolve({
+                                    etag: getSHA1(dataToBeCached)
+                                });
+                            });
+                        }
                     }
-                }
-            });
-        } else {
-            // We didn't receive a previous hash, so update the cache blindly.
-            self.redisClient.set(key, dataToBeCached, function (redisErr) {
-                if (redisErr) {
-                    var err = errors.errorCodes.UPDATE_FAILED;
-                    return deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-                }
-
-                deferred.resolve({
-                    etag: getSHA1(dataToBeCached)
                 });
-            });
-        }
-        return deferred.promise;
+            } else {
+                // We didn't receive a previous hash, so update the cache blindly.
+                self.redisClient.set(key, dataToBeCached, function (redisErr) {
+                    if (redisErr) {
+                        var err = errors.errorCodes.UPDATE_FAILED;
+                        return reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+                    }
+
+                    resolve({
+                        etag: getSHA1(dataToBeCached)
+                    });
+                });
+            }
+        });
     };
 
     /**
@@ -196,23 +186,23 @@
      * ```
      *
      * @param key `String`. **Required**. Identifies the data being retrieved
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     RedisCache.prototype.head = function (key) {
-        var self = this,
-            deferred = Q.defer();
+        var self = this;
 
-        self.redisClient.get(key, function (redisErr, data) {
-            if (redisErr || !data) {
-                var err = errors.errorCodes.CACHE_NOT_FOUND;
-                return deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-            }
+        return new Promise(function (resolve, reject) {
+            self.redisClient.get(key, function (redisErr, data) {
+                if (redisErr || !data) {
+                    var err = errors.errorCodes.CACHE_NOT_FOUND;
+                    return reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+                }
 
-            deferred.resolve({
-                etag: getSHA1(data)
+                resolve({
+                    etag: getSHA1(data)
+                });
             });
         });
-        return deferred.promise;
     };
 
     /**
@@ -230,32 +220,32 @@
      *
      * @param key `String`. **Required**. Identifies the data being retrieved
      * @param ifNewerHash `String`. _Optional_. If provided only retrieves the cached data if the hashes do not match, otherwise it just retrieves everything
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     RedisCache.prototype.restore = function (key, ifNewerHash) {
-        var self = this,
-            deferred = Q.defer();
+        var self = this;
 
-        self.redisClient.get(key, function (redisErr, data) {
-            if (redisErr || !data) {
-                var err = errors.errorCodes.CACHE_NOT_FOUND;
-                return deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-            }
+        return new Promise(function (resolve, reject) {
+            self.redisClient.get(key, function (redisErr, data) {
+                if (redisErr || !data) {
+                    var err = errors.errorCodes.CACHE_NOT_FOUND;
+                    return reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+                }
 
-            var storedHash = getSHA1(data);
-            // If we were sent a hash, only return data if it doesn't match what is currently stored.
-            if (ifNewerHash && ifNewerHash === storedHash) {
-                deferred.resolve({
-                    etag: storedHash
-                });
-            } else {
-                deferred.resolve({
-                    etag: storedHash,
-                    body: data
-                });
-            }
+                var storedHash = getSHA1(data);
+                // If we were sent a hash, only return data if it doesn't match what is currently stored.
+                if (ifNewerHash && ifNewerHash === storedHash) {
+                    resolve({
+                        etag: storedHash
+                    });
+                } else {
+                    resolve({
+                        etag: storedHash,
+                        body: data
+                    });
+                }
+            });
         });
-        return deferred.promise;
     };
 
     /**
@@ -273,47 +263,47 @@
      *
      * @param key `String`. **Required**. Identifies the data being deleted
      * @param hashToDelete `String`. _Optional_. If provided only deletes the cache if the hashes match, otherwise it just deletes the cache
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     RedisCache.prototype.remove = function (key, hashToDelete) {
         var self = this,
-            deferred = Q.defer(),
             err;
 
-        self.redisClient.get(key, function (redisErr, data) {
-            if (redisErr || !data) {
-                err = errors.errorCodes.CACHE_NOT_FOUND;
-                return deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-            }
+        return new Promise(function (resolve, reject) {
+            self.redisClient.get(key, function (redisErr, data) {
+                if (redisErr || !data) {
+                    err = errors.errorCodes.CACHE_NOT_FOUND;
+                    return reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+                }
 
-            if (hashToDelete) {
-                var storedHash = getSHA1(data);
-                // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
-                if (storedHash !== hashToDelete) {
-                    err = errors.errorCodes.HASH_MISMATCH;
-                    deferred.reject(new errors.CacheError(err.name, util.format(err.message, hashToDelete, storedHash), err.code));
+                if (hashToDelete) {
+                    var storedHash = getSHA1(data);
+                    // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
+                    if (storedHash !== hashToDelete) {
+                        err = errors.errorCodes.HASH_MISMATCH;
+                        reject(new errors.CacheError(err.name, util.format(err.message, hashToDelete, storedHash), err.code));
+                    } else {
+                        // Otherwise hashes match, so go ahead and delete the cache.
+                        self.redisClient.del(key, function (redisErr) {
+                            if (redisErr) {
+                                var err = errors.errorCodes.DELETE_FAILED;
+                                return reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + redisErr, err.code));
+                            }
+                            resolve();
+                        });
+                    }
                 } else {
-                    // Otherwise hashes match, so go ahead and delete the cache.
+                    // We didn't receive a previous hash, so delete the cache blindly.
                     self.redisClient.del(key, function (redisErr) {
                         if (redisErr) {
                             var err = errors.errorCodes.DELETE_FAILED;
-                            return deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + redisErr, err.code));
+                            return reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
                         }
-                        deferred.resolve();
+                        resolve();
                     });
                 }
-            } else {
-                // We didn't receive a previous hash, so delete the cache blindly.
-                self.redisClient.del(key, function (redisErr) {
-                    if (redisErr) {
-                        var err = errors.errorCodes.DELETE_FAILED;
-                        return deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
-                    }
-                    deferred.resolve();
-                });
-            }
+            });
         });
-        return deferred.promise;
     };
 
     /**
@@ -329,17 +319,18 @@
      * });
      * ```
      *
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     RedisCache.prototype.keys = function () {
-        var deferred = Q.defer();
-        this.redisClient.getKeys(function (err, result) {
-            if (err) {
-                return deferred.reject(err);
-            }
-            deferred.resolve(result);
+        var self = this;
+        return new Promise(function (resolve, reject) {
+            self.redisClient.getKeys(function (err, result) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result);
+            });
         });
-        return deferred.promise;
     };
 
     /**
@@ -367,17 +358,18 @@
      * })
      * ```
      * @param {string} key - key value used for cached item
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     RedisCache.prototype.exists = function (key) {
-        var deferred = Q.defer();
-        this.redisClient.exists(key, function (err, result) {
-            if (err) {
-                return deferred.reject(err);
-            }
-            deferred.resolve(result === 1); // Redis returns 0/1 not true/false. See: http://redis.io/commands/exists
+        var self = this;
+        return new Promise(function (resolve, reject) {
+            self.redisClient.exists(key, function (err, result) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result === 1); // Redis returns 0/1 not true/false. See: http://redis.io/commands/exists
+            });
         });
-        return deferred.promise;
     };
 
     var getSHA1 = function (data) {
@@ -385,5 +377,5 @@
     };
 
     module.exports = RedisCache;
-}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('q'), require('../errors'), require('jssha'),
-    require('events').EventEmitter, require('redis'), process));
+}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('bluebird'), require('../errors'), require('jssha'),
+    require('events').EventEmitter, require('redis')));

--- a/lib/cacheImpl/s3.js
+++ b/lib/cacheImpl/s3.js
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-(function (module, cacheInterface, inherit, util, S3FS, Q, errors, process) {
+(function (module, cacheInterface, inherit, util, S3FS, Promise, errors) {
     'use strict';
     var requiredArgs = [
         {
@@ -73,31 +73,22 @@
         );
         this.getOrCreateSet = function getOrCreateSet(key) {
             if (S3Cache.Set) {
-                return key in sets ? sets[key] : sets[key] = (function (key) {
-                    var deferred = Q.defer(),
-                        setInstance;
-                    process.nextTick(function () {
-                        try {
-                            setInstance = new S3Cache.Set(key, self);
-                            setInstance.on('destroy', function () {
-                                delete sets[key];
-                            });
-                            setInstance.on('error', function (err) {
-                                delete sets[key];
-                                deferred.reject(err);
-                            });
-                            setInstance.on('ready', function () {
-                                deferred.resolve(setInstance);
-                            });
-                        } catch (err) {
-                            deferred.reject(err);
-                        }
+                return key in sets ? sets[key] : sets[key] = new Promise(function (resolve, reject) {
+                    var setInstance = new S3Cache.Set(key, self);
+                    setInstance.on('destroy', function () {
+                        delete sets[key];
                     });
-                    return deferred.promise;
-                }(key));
+                    setInstance.on('error', function (err) {
+                        delete sets[key];
+                        reject(err);
+                    });
+                    setInstance.on('ready', function () {
+                        resolve(setInstance);
+                    });
+                });
             }
             var err = errors.errorCodes.SET_NOT_DEFINED;
-            return Q.reject(new errors.CacheError(err.name, err.message, err.code));
+            return Promise.reject(new errors.CacheError(err.name, err.message, err.code));
         };
 
     }
@@ -120,55 +111,55 @@
      * @param dataToBeCached `String`. **Required**. The data to be stored
      * @param key `String`. **Required**. Identifies the data being stored, used later to retrieve, update, or restore the cache
      * @param hashToReplace `String` _Optional_ If provided, only updates the cache when the hash value provided is the same as what is currently stored. If there isn't a cache currently created it will persist the data regardless.
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     S3Cache.prototype.save = function (dataToBeCached, key, hashToReplace) {
         var self = this,
-            urlEncodedKey = encodeURIComponent(key),
-            deferred = Q.defer();
-        // If we were sent a hash, we only want to update the cache if the hash matches what is currently stored.
-        if (hashToReplace) {
-            self.s3fs.headObject(urlEncodedKey).then(function (data) {
-                var storedHash = normalizeETag(data.ETag);
-                // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
-                if (storedHash !== hashToReplace) {
-                    var err = errors.errorCodes.HASH_MISMATCH;
-                    deferred.reject(new errors.CacheError(err.name, util.format(err.message, hashToReplace, storedHash), err.code));
-                } else {
-                    // Otherwise hashes match, so go ahead and update the cache.
+            urlEncodedKey = encodeURIComponent(key);
+        return new Promise(function (resolve, reject) {
+            // If we were sent a hash, we only want to update the cache if the hash matches what is currently stored.
+            if (hashToReplace) {
+                self.s3fs.headObject(urlEncodedKey).then(function (data) {
+                    var storedHash = normalizeETag(data.ETag);
+                    // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
+                    if (storedHash !== hashToReplace) {
+                        var err = errors.errorCodes.HASH_MISMATCH;
+                        reject(new errors.CacheError(err.name, util.format(err.message, hashToReplace, storedHash), err.code));
+                    } else {
+                        // Otherwise hashes match, so go ahead and update the cache.
+                        self.s3fs.writeFile(urlEncodedKey, dataToBeCached).then(function (data) {
+                            resolve({
+                                etag: normalizeETag(data.ETag)
+                            });
+                        }, function (reason) {
+                            var err = errors.errorCodes.UPDATE_FAILED;
+                            reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' +
+                            reason, err.code));
+                        });
+                    }
+                }, function () {
+                    // If we try to update a key that doesn't exist, update it anyways.
                     self.s3fs.writeFile(urlEncodedKey, dataToBeCached).then(function (data) {
-                        deferred.resolve({
+                        resolve({
                             etag: normalizeETag(data.ETag)
                         });
                     }, function (reason) {
                         var err = errors.errorCodes.UPDATE_FAILED;
-                        deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' +
-                        reason, err.code));
+                        reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + reason, err.code));
                     });
-                }
-            }, function () {
-                // If we try to update a key that doesn't exist, update it anyways.
+                });
+            } else {
+                // We didn't receive a previous hash, so update the cache blindly.
                 self.s3fs.writeFile(urlEncodedKey, dataToBeCached).then(function (data) {
-                    deferred.resolve({
+                    resolve({
                         etag: normalizeETag(data.ETag)
                     });
                 }, function (reason) {
                     var err = errors.errorCodes.UPDATE_FAILED;
-                    deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + reason, err.code));
+                    reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + reason, err.code));
                 });
-            });
-        } else {
-            // We didn't receive a previous hash, so update the cache blindly.
-            self.s3fs.writeFile(urlEncodedKey, dataToBeCached).then(function (data) {
-                deferred.resolve({
-                    etag: normalizeETag(data.ETag)
-                });
-            }, function (reason) {
-                var err = errors.errorCodes.UPDATE_FAILED;
-                deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' + reason, err.code));
-            });
-        }
-        return deferred.promise;
+            }
+        });
     };
 
     /**
@@ -185,22 +176,22 @@
      * ```
      *
      * @param key `String`. **Required**. Identifies the data being retrieved
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     S3Cache.prototype.head = function (key) {
         var self = this,
-            urlEncodedKey = encodeURIComponent(key),
-            deferred = Q.defer();
+            urlEncodedKey = encodeURIComponent(key);
 
-        self.s3fs.headObject(urlEncodedKey).then(function (data) {
-            deferred.resolve({
-                etag: normalizeETag(data.ETag)
+        return new Promise(function (resolve, reject) {
+            self.s3fs.headObject(urlEncodedKey).then(function (data) {
+                resolve({
+                    etag: normalizeETag(data.ETag)
+                });
+            }, function () {
+                var err = errors.errorCodes.CACHE_NOT_FOUND;
+                reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
             });
-        }, function () {
-            var err = errors.errorCodes.CACHE_NOT_FOUND;
-            deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
         });
-        return deferred.promise;
     };
 
     /**
@@ -218,31 +209,31 @@
      *
      * @param key `String`. **Required**. Identifies the data being retrieved
      * @param ifNewerHash `String`. _Optional_. If provided only retrieves the cached data if the hashes do not match, otherwise it just retrieves everything
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     S3Cache.prototype.restore = function (key, ifNewerHash) {
         var self = this,
-            urlEncodedKey = encodeURIComponent(key),
-            deferred = Q.defer();
+            urlEncodedKey = encodeURIComponent(key);
 
-        self.s3fs.readFile(urlEncodedKey).then(function (data) {
-            var storedHash = normalizeETag(data.ETag);
-            // If we were sent a hash, only return data if it doesn't match what is currently stored.
-            if (ifNewerHash && ifNewerHash === storedHash) {
-                deferred.resolve({
-                    etag: storedHash
-                });
-            } else {
-                deferred.resolve({
-                    etag: storedHash,
-                    body: data.Body.toString()
-                });
-            }
-        }, function () {
-            var err = errors.errorCodes.CACHE_NOT_FOUND;
-            deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+        return new Promise(function (resolve, reject) {
+            self.s3fs.readFile(urlEncodedKey).then(function (data) {
+                var storedHash = normalizeETag(data.ETag);
+                // If we were sent a hash, only return data if it doesn't match what is currently stored.
+                if (ifNewerHash && ifNewerHash === storedHash) {
+                    resolve({
+                        etag: storedHash
+                    });
+                } else {
+                    resolve({
+                        etag: storedHash,
+                        body: data.Body.toString()
+                    });
+                }
+            }, function () {
+                var err = errors.errorCodes.CACHE_NOT_FOUND;
+                reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+            });
         });
-        return deferred.promise;
     };
 
     /**
@@ -260,45 +251,45 @@
      *
      * @param key `String`. **Required**. Identifies the data being deleted
      * @param hashToDelete `String`. _Optional_. If provided only deletes the cache if the hashes match, otherwise it just deletes the cache
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     S3Cache.prototype.remove = function (key, hashToDelete) {
         var self = this,
-            urlEncodedKey = encodeURIComponent(key),
-            deferred = Q.defer();
+            urlEncodedKey = encodeURIComponent(key);
 
-        self.s3fs.headObject(urlEncodedKey).then(function (data) {
-            if (hashToDelete) {
-                var storedHash = normalizeETag(data.ETag);
-                // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
-                if (storedHash !== hashToDelete) {
-                    var err = errors.errorCodes.HASH_MISMATCH;
-                    deferred.reject(new errors.CacheError(err.name, util.format(err.message, hashToDelete, storedHash), err.code));
+        return new Promise(function (resolve, reject) {
+            self.s3fs.headObject(urlEncodedKey).then(function (data) {
+                if (hashToDelete) {
+                    var storedHash = normalizeETag(data.ETag);
+                    // If we have mismatched hashes, something is out-of-sync send back a response so that the client can update.
+                    if (storedHash !== hashToDelete) {
+                        var err = errors.errorCodes.HASH_MISMATCH;
+                        reject(new errors.CacheError(err.name, util.format(err.message, hashToDelete, storedHash), err.code));
+                    } else {
+                        // Otherwise hashes match, so go ahead and delete the cache.
+                        self.s3fs.unlink(urlEncodedKey).then(function () {
+                            resolve();
+                        }, function (reason) {
+                            var err = errors.errorCodes.DELETE_FAILED;
+                            reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' +
+                            reason, err.code));
+                        });
+                    }
                 } else {
-                    // Otherwise hashes match, so go ahead and delete the cache.
+                    // We didn't receive a previous hash, so delete the cache blindly.
                     self.s3fs.unlink(urlEncodedKey).then(function () {
-                        deferred.resolve();
+                        resolve();
                     }, function (reason) {
                         var err = errors.errorCodes.DELETE_FAILED;
-                        deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' +
+                        reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' +
                         reason, err.code));
                     });
                 }
-            } else {
-                // We didn't receive a previous hash, so delete the cache blindly.
-                self.s3fs.unlink(urlEncodedKey).then(function () {
-                    deferred.resolve();
-                }, function (reason) {
-                    var err = errors.errorCodes.DELETE_FAILED;
-                    deferred.reject(new errors.CacheError(err.name, util.format(err.message, key) + ' - ' +
-                    reason, err.code));
-                });
-            }
-        }, function () {
-            var err = errors.errorCodes.CACHE_NOT_FOUND;
-            deferred.reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+            }, function () {
+                var err = errors.errorCodes.CACHE_NOT_FOUND;
+                reject(new errors.CacheError(err.name, util.format(err.message, key), err.code));
+            });
         });
-        return deferred.promise;
     };
 
     /**
@@ -315,7 +306,7 @@
     S3Cache.prototype.set = function (setKey) {
         if (!setKey) {
             var err = new Error(util.format('Invalid Argument Type Expected [%s] for [%s] but got [%s]', 'string', 'setKey', typeof setKey));
-            return Q.reject(err);
+            return Promise.reject(err);
         }
         return this.getOrCreateSet(setKey);
     };
@@ -333,7 +324,7 @@
      * });
      * ```
      *
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     S3Cache.prototype.keys = function () {
         return this.s3fs.readdir().then(function (files) {
@@ -351,16 +342,16 @@
      * })
      * ```
      * @param {string} key - key value used for cached item
-     * @returns {Q.promise}
+     * @returns {Promise}
      */
     S3Cache.prototype.exists = function (key) {
-        var deferred = Q.defer(),
-            self = this,
+        var self = this,
             urlEncodedKey = encodeURIComponent(key);
-        self.s3fs.exists(urlEncodedKey, function (exists) {
-            deferred.resolve(exists);
+        return new Promise(function (resolve) {
+            self.s3fs.exists(urlEncodedKey, function (exists) {
+                resolve(exists);
+            });
         });
-        return deferred.promise;
     };
 
     /**
@@ -375,4 +366,4 @@
     }
 
     module.exports = S3Cache;
-}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('s3fs'), require('q'), require('../errors'), process));
+}(module, require('../cacheInterface'), require('inherit-multiple'), require('util'), require('s3fs'), require('bluebird'), require('../errors')));

--- a/lib/setImpl/fs.js
+++ b/lib/setImpl/fs.js
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-(function (module, inherit, util, setInterface, cbQ, path, EventEmitter, FSCache) {
+(function (module, inherit, util, setInterface, path, EventEmitter, FSCache) {
     'use strict';
     var requiredArgs = [
         {
@@ -55,10 +55,12 @@
         self.xfs = parent.xfs;
         self.path = path.join(parent.path, key);
 
-        var mkdir = cbQ.cb();
-        parent.xfs.mkdir(self.path, mkdir);
+        self.readFileAsync = parent.readFileAsync;
+        self.writeFileAsync = parent.writeFileAsync;
+        self.unlinkAsync = parent.unlinkAsync;
+        self.readdirAsync = parent.readdirAsync;
 
-        mkdir.promise.then(function () {
+        self.xfs.mkdirp(self.path).then(function () {
             self.emit('ready');
         }, function (err) {
             self.emit('error', err);
@@ -74,13 +76,11 @@
     };
 
     FSSet.prototype.destroy = function () {
-        var self = this,
-            rmdir = cbQ.cb();
-        self.xfs.rmdir(this.path, rmdir);
-        return rmdir.promise.then(function () {
+        var self = this;
+        return self.xfs.rmdirp(self.path).then(function () {
             self.emit('destroy');
         });
     };
 
     module.exports = FSSet;
-}(module, require('inherit-multiple'), require('util'), require('../setInterface'), require('cb-q'), require('path'), require('events').EventEmitter, require('../cacheImpl/fs')));
+}(module, require('inherit-multiple'), require('util'), require('../setInterface'), require('path'), require('events').EventEmitter, require('../cacheImpl/fs')));

--- a/lib/setImpl/mem.js
+++ b/lib/setImpl/mem.js
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-(function (module, inherit, Interface, MemCache, EventEmitter, process, q) {
+(function (module, process, inherit, Interface, MemCache, EventEmitter, Promise) {
     'use strict';
 
     function MemSet(key, parent) {
@@ -63,12 +63,8 @@
     };
 
     MemSet.prototype.destroy = function () {
-        var deferred = q.defer();
         this.emit('destroy');
-        process.nextTick(function () {
-            deferred.resolve();
-        });
-        return deferred.promise;
+        return Promise.resolve();
     };
 
     MemSet.prototype.exists = function (key) {
@@ -77,4 +73,4 @@
 
     module.exports = MemSet;
 
-}(module, require('inherit-multiple'), require('../setInterface'), require('../cacheImpl/mem'), require('events').EventEmitter, process, require('q')));
+}(module, process, require('inherit-multiple'), require('../setInterface'), require('../cacheImpl/mem'), require('events').EventEmitter, require('bluebird')));

--- a/lib/setImpl/redis.js
+++ b/lib/setImpl/redis.js
@@ -60,6 +60,7 @@
             };
         hset.forEach(function (command) {
             redisSetProxyClient[command] = self.redisClient['h' + command].bind(self.redisClient, key);
+            self[command + 'Async'] = Promise.promisify(redisSetProxyClient[command]);
         });
 
         redisSetProxyClient.destroy = Promise.promisify(self.redisClient.del.bind(self.redisClient, key));
@@ -71,6 +72,8 @@
                 return cb(err, keys.filter(removeHsetPlaceholder));
             });
         };
+
+        self.getKeysAsync = Promise.promisify(redisSetProxyClient.getKeys);
 
         self.redisClient = redisSetProxyClient;
         parent.redisClient.hset([key, hsetPlaceholder, null], function (err) {

--- a/lib/setImpl/redis.js
+++ b/lib/setImpl/redis.js
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-(function (module, inherit, Interface, Q, EventEmitter, RedisCache, uuid, util) {
+(function (module, inherit, Interface, Promise, EventEmitter, RedisCache, uuid, util) {
     'use strict';
     var requiredArgs = [
             {
@@ -33,7 +33,7 @@
 
     /**
      * Create an instance of the S3 cache implementation.
-     *  @property {string} `key`. **Required**. the set key
+     * @param key `String`. **Required**. the set key
      * @param parent `Object`. **Required**. The parent to use to create the S3 client
      * @returns {RedisSet} An implementation of the set interface using Amazon S3 as the storage system
      * @constructor
@@ -62,7 +62,7 @@
             redisSetProxyClient[command] = self.redisClient['h' + command].bind(self.redisClient, key);
         });
 
-        redisSetProxyClient.destroy = self.redisClient.del.bind(self.redisClient, key);
+        redisSetProxyClient.destroy = Promise.promisify(self.redisClient.del.bind(self.redisClient, key));
         redisSetProxyClient.getKeys = function (cb) {
             parent.redisClient.hkeys(key, function (err, keys) {
                 if (err) {
@@ -90,13 +90,11 @@
     };
 
     RedisSet.prototype.destroy = function () {
-        var deferred = Q.defer(),
-            self = this;
-        this.redisClient.destroy(deferred.makeNodeResolver());
-        return deferred.promise.then(function () {
+        var self = this;
+        this.redisClient.destroy().then(function () {
             self.emit('destroy');
         });
     };
 
     module.exports = RedisSet;
-}(module, require('inherit-multiple'), require('../setInterface'), require('q'), require('events').EventEmitter, require('../cacheImpl/redis'), require('uuid'), require('util')));
+}(module, require('inherit-multiple'), require('../setInterface'), require('bluebird'), require('events').EventEmitter, require('../cacheImpl/redis'), require('uuid'), require('util')));

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "bluebird": "^2.x",
     "fs-wishlist": "^1.x",
     "inherit-multiple": "^1.x",
-    "jssha": "^1.x",
     "redis": "^0.x",
     "s3fs": "^1.x",
     "uuid": "^2.x"

--- a/package.json
+++ b/package.json
@@ -42,11 +42,10 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "cb-q": "^0.x",
+    "bluebird": "^2.x",
+    "fs-wishlist": "^1.x",
     "inherit-multiple": "^1.x",
     "jssha": "^1.x",
-    "mkdirp": "^0.x",
-    "q": "^1.x",
     "redis": "^0.x",
     "s3fs": "^1.x",
     "uuid": "^2.x"
@@ -62,7 +61,6 @@
     "jsinspect": "^0.x",
     "mocha": "^2.x",
     "nsp": "^1.x",
-    "rmdir": "^1.x",
     "should": "^5.x",
     "reporter-file": "^1.x"
   },

--- a/test/impls.js
+++ b/test/impls.js
@@ -1,4 +1,4 @@
-(function (expect, util, Q, lib, errors) {
+(function (expect, util, Promise, lib, errors) {
     'use strict';
     describe('Implementation Tests', function () {
         var redisClient,
@@ -9,7 +9,7 @@
                 {
                     name: 'Memory',
                     createCache: function () {
-                        return Q.when(lib.cache('mem', {}));
+                        return Promise.resolve(lib.cache('mem', {}));
                     },
                     dataToSave: {
                         name: 'Zul'
@@ -47,7 +47,7 @@
                         /* jshint camelcase: true */
                     },
                     createCache: function () {
-                        return Q.when(lib.cache('redis',
+                        return Promise.resolve(lib.cache('redis',
                             {
                                 host: 'localhost',
                                 port: 6379,
@@ -114,7 +114,7 @@
                         s3fsImpl.destroy().then(done, done);
                     },
                     createCache: function () {
-                        return Q.when(lib.cache('s3',
+                        return Promise.resolve(lib.cache('s3',
                             {
                                 bucket: bucketName,
                                 accessKeyId: s3Credentials.accessKeyId,
@@ -175,12 +175,10 @@
                         done();
                     },
                     afterEach: function (done) {
-                        require('rmdir')(bucketName, function (err) {
-                            done(err);
-                        });
+                        require('fs-wishlist').mixin(require('fs')).rmdirp(bucketName).then(done, done);
                     },
                     createCache: function () {
-                        return Q.when(lib.cache('fs',
+                        return Promise.resolve(lib.cache('fs',
                             {
                                 path: bucketName,
                                 fs: require('fs')
@@ -203,9 +201,7 @@
                         done();
                     },
                     afterEach: function (done) {
-                        require('rmdir')(bucketName, function (err) {
-                            done(err);
-                        });
+                        require('fs-wishlist').mixin(require('fs')).rmdirp(bucketName).then(done, done);
                     },
                     createCache: function () {
                         return lib.cache('fs',
@@ -405,4 +401,4 @@
             });
         });
     });
-}(require('./chaiPromise').expect, require('util'), require('q'), require('../index'), require('../lib/errors')));
+}(require('./chaiPromise').expect, require('util'), require('bluebird'), require('../index'), require('../lib/errors')));

--- a/test/set.js
+++ b/test/set.js
@@ -1,4 +1,4 @@
-(function (expect, Q, lib) {
+(function (expect, Promise, lib) {
     'use strict';
     describe('Set Specific Tests', function () {
         var redisClient,
@@ -9,7 +9,7 @@
                 {
                     name: 'Memory Set',
                     createCache: function () {
-                        return Q.when(lib.cache('mem', {}));
+                        return Promise.resolve(lib.cache('mem', {}));
                     }
                 },
                 {
@@ -25,7 +25,7 @@
                         /* jshint camelcase: true */
                     },
                     createCache: function () {
-                        return Q.when(lib.cache('redis',
+                        return Promise.resolve(lib.cache('redis',
                             {
                                 host: 'localhost',
                                 port: 6379,
@@ -54,7 +54,7 @@
                         s3fsImpl.destroy().then(done, done);
                     },
                     createCache: function () {
-                        return Q.when(lib.cache('s3',
+                        return Promise.resolve(lib.cache('s3',
                             {
                                 bucket: bucketName,
                                 accessKeyId: s3Credentials.accessKeyId,
@@ -70,12 +70,10 @@
                         done();
                     },
                     afterEach: function (done) {
-                        require('rmdir')(bucketName, function (err) {
-                            done(err);
-                        });
+                        require('fs-wishlist').mixin(require('fs')).rmdirp(bucketName).then(done, done);
                     },
                     createCache: function () {
-                        return Q.when(lib.cache('fs',
+                        return Promise.resolve(lib.cache('fs',
                             {
                                 path: bucketName,
                                 fs: require('fs')
@@ -139,4 +137,4 @@
             });
         });
     });
-}(require('./chaiPromise').expect, require('q'), require('../index')));
+}(require('./chaiPromise').expect, require('bluebird'), require('../index')));


### PR DESCRIPTION
This PR switches over to Bluebird for our promises (as well as making use of Bluebird to remove some dependencies), it also switches over our usage of modules (such as mkdir) to our mixins library. Lastly, this moves the library over from `jssha` to Node's native `crypto` module for calculating hashes.