### PR TITLE
Support Dynamic AWS Credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ node_js:
 - '0.10'
 - '0.11'
 - '0.12'
-- 'iojs'
+- iojs
 env:
   global:
-  - secure: Ua3Js0aFlkkdJvODwYqpHR1aKZJt7/WI/v3JBQyZW0SlhS2645WiTeZ1HuVSznr8Fu2R4rqI1YCt0/GKQ9q3ZzIJqS8B7Y9Z7BsYOx/mZ8ztk1szYH489T0z0IkFPdacJ832rntZM+1AAxrnc2pAX4qeLF5EkQ+4hofd26E2PIk=
-  - secure: UvLTfuT2JOhv5MpjODNE23GZLb6npMck8eKphq0PSr9d71ehC42nadIL5FCbakKvQKlHJ/hxKykraQqAuBypFWc1rmPacv22YC5yKrel7zUMZIipGz/+ABpGu6utvX7wr5cMyH8vlxyqWJdE1uqswpGEWdTO/lBYECaZ7PTlwno=
-  - secure: SNsdjtWd5mNDNkbLs4kLl+XNtgbTLrXpz54n0Cr5Qfvu9XOirP1Nqd1OJi+o6D0IpsJSHru4V4l8qx+zNKrzCWb2EqceXQHn57k/QfYozRxZS7scOgz8KIT2XDZvO1FayMm4LtfHv/YpC5NGcGVPSvj+n5e/TFmYkh9mt5BqKJg=
+  - secure: J+ahu8EtsOzhGFGWbe8oBPgRQCNTSy6uVk/zxi8c84+N5HBtLr3GC+YR5ZS2h0Ux2E53x7sWum10di8Ixr6EhuqSEjDmJGiZFW6oHTsXrMhT8X6RgHT+cPJnJwTLjlBZFA3JgT8Qyh1J3fcy3PiZjOMfyi+vt8Eihnw799QfuzE=
+  - secure: KdN40eA1ExI0w09S9lMPfdqN98bXTBIr4jIr1kzZloQLuy6iLuBqvUKbOxvg6pu4hnxaKiSijve1cez1+KHCHC6rdTfVf62A4Q6pQUKwEAb42KtQZ4WHf7E0RA2i/5d+gUGqSNx+kR42o2blnYASZLrQkFem8cY5ENNbztLFEKE=
 script: npm test
-after_script: npm run-script inspect && npm install coveralls && cat ./coverage/lcov.info | coveralls
+after_script: npm run-script inspect && npm install coveralls && cat ./coverage/lcov.info
+  | coveralls
 services:
 - redis-server

--- a/README.md
+++ b/README.md
@@ -131,9 +131,7 @@ The S3 implementation uses the [module](https://www.npmjs.com/package/s3fs) modu
 var mightyCache = require('mightycache');
 var cache = mightyCache.cache('s3',
     {
-        bucket: 'test-bucket',
-        accessKeyId: 'Access Key Id Goes Here',
-        secretAccessKey: 'Secret Access Key Goes Here'
+        bucket: 'test-bucket'
     }
 );
 ```
@@ -142,8 +140,8 @@ var cache = mightyCache.cache('s3',
 Name | Type | Description
 ---------|--------|----------------
 `bucket`|`string`|**Required**. Bucket to be used to store cache data in. This can include both the bucket and a path. (Ex. `test-bucket/cache/data`)
-`accessKeyId`|`string`|**Required**. Access Key Id to be used to connect to S3.
-`secretAccessKey`|`string`|**Required**. Secret Access Key corresponding to the provided Access Key Id to allow authentication to access S3.
+`accessKeyId`|`string`|**Optional**. Access Key Id to be used to connect to S3. The AWS SDK can [pull in variables dynamically](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials).
+`secretAccessKey`|`string`|**Optional**. Secret Access Key corresponding to the provided Access Key Id to allow authentication to access S3. The AWS SDK can [pull in variables dynamically](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials).
 
 ### Memory
 The in-memory implementation which is meant for testing purposes only as it is not mature, therefore it is **not production ready**

--- a/lib/cacheImpl/s3.js
+++ b/lib/cacheImpl/s3.js
@@ -27,14 +27,6 @@
         {
             name: 'bucket',
             type: 'string'
-        },
-        {
-            name: 'accessKeyId',
-            type: 'string'
-        },
-        {
-            name: 'secretAccessKey',
-            type: 'string'
         }
     ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mightycache",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Module providing multiple implementations of a cache backed by a data store.",
   "keywords": [
     "cache",

--- a/test/impls.js
+++ b/test/impls.js
@@ -178,6 +178,62 @@
                 {
                     name: 'S3',
                     before: function () {
+                        bucketName = 'mightycache-s3-test-bucket-' + (Math.random() + '').slice(2, 8);
+
+                        s3fsImpl = require('s3fs')(bucketName);
+
+                        return s3fsImpl.create();
+                    },
+                    after: function () {
+                        return s3fsImpl.destroy();
+                    },
+                    createCache: function () {
+                        return Promise.resolve(lib.cache('s3',
+                            {
+                                bucket: bucketName
+                            }
+                        ));
+                    },
+                    dataToSave: {
+                        name: 'Zul'
+                    },
+                    dataToSaveHash: '5bf48f033197ecd3635f459c145b0815',
+                    dataToUpdate: {
+                        name: 'Odoyle Rules!'
+                    },
+                    dataToUpdateHash: 'd9b4bc4b39054b07b6f2512abcdad03f'
+                },
+                {
+                    name: 'S3 Set',
+                    before: function () {
+                        bucketName = 'mightycache-s3-set-test-bucket-' + (Math.random() + '').slice(2, 8);
+
+                        s3fsImpl = require('s3fs')(bucketName);
+
+                        return s3fsImpl.create();
+                    },
+                    after: function () {
+                        return s3fsImpl.destroy();
+                    },
+                    createCache: function () {
+                        return lib.cache('s3',
+                            {
+                                bucket: bucketName
+                            }
+                        ).set('test');
+                    },
+                    dataToSave: {
+                        name: 'Zul'
+                    },
+                    dataToSaveHash: '5bf48f033197ecd3635f459c145b0815',
+                    dataToUpdate: {
+                        name: 'Odoyle Rules!'
+                    },
+                    dataToUpdateHash: 'd9b4bc4b39054b07b6f2512abcdad03f'
+                },
+                {
+                    name: 'S3 Hardcoded Credentials',
+                    before: function () {
                         s3Credentials = {
                             accessKeyId: process.env.AWS_ACCESS_KEY_ID,
                             secretAccessKey: process.env.AWS_SECRET_KEY,
@@ -211,7 +267,7 @@
                     dataToUpdateHash: 'd9b4bc4b39054b07b6f2512abcdad03f'
                 },
                 {
-                    name: 'S3 Set',
+                    name: 'S3 Set Hardcoded Credentials',
                     before: function () {
                         s3Credentials = {
                             accessKeyId: process.env.AWS_ACCESS_KEY_ID,

--- a/test/s3.js
+++ b/test/s3.js
@@ -23,7 +23,7 @@
  */
 (function (expect, lib) {
     'use strict';
-    describe('S3 Specific Implementation', function () {
+    describe.only('S3 Specific Implementation', function () {
         it('Shouldn\'t be able to instantiate the S3 cache implementation without a bucket', function () {
             expect(function () {
                 lib.cache('s3', {});
@@ -37,46 +37,6 @@
                     }
                 );
             }).to.throw(Error, 'Invalid Argument Type Expected [string] for [bucket] but got [object]');
-        });
-        it('Shouldn\'t be able to instantiate the S3 cache implementation without an access key id', function () {
-            expect(function () {
-                lib.cache('s3',
-                    {
-                        bucket: 'test'
-                    }
-                );
-            }).to.throw(Error, 'Missing Required Argument [accessKeyId]');
-        });
-        it('Shouldn\'t be able to instantiate the S3 cache implementation with an invalid access key id', function () {
-            expect(function () {
-                lib.cache('s3',
-                    {
-                        bucket: 'test',
-                        accessKeyId: {}
-                    }
-                );
-            }).to.throw(Error, 'Invalid Argument Type Expected [string] for [accessKeyId] but got [object]');
-        });
-        it('Shouldn\'t be able to instantiate the S3 cache implementation without a secret access key', function () {
-            expect(function () {
-                lib.cache('s3',
-                    {
-                        bucket: 'test',
-                        accessKeyId: 'test'
-                    }
-                );
-            }).to.throw(Error, 'Missing Required Argument [secretAccessKey]');
-        });
-        it('Shouldn\'t be able to instantiate the S3 cache implementation with an invalid secret access key', function () {
-            expect(function () {
-                lib.cache('s3',
-                    {
-                        bucket: 'test',
-                        accessKeyId: 'test',
-                        secretAccessKey: {}
-                    }
-                );
-            }).to.throw(Error, 'Invalid Argument Type Expected [string] for [secretAccessKey] but got [object]');
         });
         it('Should instantiate the S3 cache implementation', function () {
             var cache = lib.cache('s3',

--- a/test/s3.js
+++ b/test/s3.js
@@ -23,7 +23,7 @@
  */
 (function (expect, lib) {
     'use strict';
-    describe.only('S3 Specific Implementation', function () {
+    describe('S3 Specific Implementation', function () {
         it('Shouldn\'t be able to instantiate the S3 cache implementation without a bucket', function () {
             expect(function () {
                 lib.cache('s3', {});


### PR DESCRIPTION
This PR removes the required keys for AWS Access Key and AWS Secret Key as these can be obtained in multiple ways when using AWS. It also adds specific sets of tests around dynamic credentials and hardcoded credentials.

Additional details around using the dynamic credentials can be found in the [AWS SDK](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials) documentation.